### PR TITLE
Add configurable port support

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ io.on('connection', (socket) => {
 
 });
 
-server.listen(3000, '0.0.0.0', () => {
-    console.log('Socket.IO server running');
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, '0.0.0.0', () => {
+    console.log(`Socket.IO server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- allow overriding the listening port with the `PORT` environment variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68809d0b194c8329a3b311c801563483