### PR TITLE
Add Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm start
 
 The server listens on `process.env.PORT` or `3000` by default.
 
-Run tests (currently just a placeholder):
+Run the unit tests:
 
 ```sh
 npm test

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,44 @@
+const { io, server } = require('..');
+const ioClient = require('socket.io-client');
+
+describe('socket server', () => {
+  let port;
+
+  beforeAll(done => {
+    server.listen(() => {
+      port = server.address().port;
+      done();
+    });
+  });
+
+  afterAll(done => {
+    io.close();
+    server.close(done);
+  });
+
+  test('broadcasts note updates to other clients', done => {
+    const client1 = ioClient(`http://localhost:${port}`);
+    const client2 = ioClient(`http://localhost:${port}`);
+
+    const roomId = 'room1';
+    const note = 'hello';
+
+    client2.on('note_update', msg => {
+      try {
+        expect(msg).toBe(note);
+        done();
+      } finally {
+        client1.close();
+        client2.close();
+      }
+    });
+
+    client1.on('connect', () => {
+      client1.emit('join', { roomId, name: 'A' });
+      client2.emit('join', { roomId, name: 'B' });
+      setTimeout(() => {
+        client1.emit('note_update', { roomId, note });
+      }, 50);
+    });
+  });
+});

--- a/index.js
+++ b/index.js
@@ -96,6 +96,11 @@ io.on('connection', (socket) => {
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, '0.0.0.0', () => {
-    console.log(`Socket.IO server running on port ${PORT}`);
-});
+
+if (require.main === module) {
+    server.listen(PORT, '0.0.0.0', () => {
+        console.log(`Socket.IO server running on port ${PORT}`);
+    });
+}
+
+module.exports = { io, server };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node ./index.js"
   },
   "keywords": [],
@@ -12,5 +12,9 @@
   "license": "ISC",
   "dependencies": {
     "socket.io": "^4.8.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "socket.io-client": "^4.7.4"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest and socket.io-client dev dependencies
- export server from index.js for use in tests
- write a basic unit test verifying note_update broadcasts
- document running tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c0cd51f88329b0c78c49ebf58a97